### PR TITLE
Update multiple match warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bitrise*
 .gows.user.yml
 _tmp
+.idea

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,7 +39,7 @@ workflows:
         inputs:
         - test_name: test name
         - base_path: ./
-        - search_pattern: '*/*.xcresult'
+        - search_pattern: "*/*.xcresult"
         - example_step_input: Example Step Input's value
     - script:
         title: Check if export succeeded

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2,17 +2,13 @@ format_version: "10"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: ""
 workflows:
-  audit-this-step:
+  check:
     steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            stepman audit --step-yml ./step.yml
+    - git::https://github.com/bitrise-steplib/steps-check.git: { }
+
   test:
     before_run:
-    - audit-this-step
+    - check
     steps:
     - change-workdir:
         title: Switch working dir to test / _tmp dir

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -40,7 +40,7 @@ workflows:
         inputs:
         - content: |-
             FIND_TEST_INFO="$(find $BITRISE_TEST_DEPLOY_DIR -name 'test-info.json' -print -quit)"
-            FIND_XCRESULT="$(find $BITRISE_TEST_DEPLOY_DIR -name '*/xcresult3_multi_level_UI_tests.xcresult' -print -quit)"
+            FIND_XCRESULT="$(find $BITRISE_TEST_DEPLOY_DIR -name 'xcresult3_multi_level_UI_tests.xcresult' -print -quit)"
             if [ -n "$FIND_TEST_INFO" ] && [ -n "$FIND_XCRESULT" ]
             then
               echo "Found exported test results at:"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -30,17 +30,11 @@ workflows:
             git clone --branch master --depth 1 https://github.com/bitrise-io/sample-artifacts.git
     - path::./:
         title: Step Test
-        description: |-
-          The example input has a default value,
-          you can overwrite it if you want to, just like we did below,
-          but the step would use the default value specified in the `step.yml`
-          file if you would not specify another value.
         run_if: "true"
         inputs:
         - test_name: test name
         - base_path: ./
-        - search_pattern: "*/*.xcresult"
-        - example_step_input: Example Step Input's value
+        - search_pattern: "*/xcresult3_multi_level_UI_tests.xcresult"
     - script:
         title: Check if export succeeded
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -46,7 +46,7 @@ workflows:
         inputs:
         - content: |-
             FIND_TEST_INFO="$(find $BITRISE_TEST_DEPLOY_DIR -name 'test-info.json' -print -quit)"
-            FIND_XCRESULT="$(find $BITRISE_TEST_DEPLOY_DIR -name 'xcresult3_multi_level_UI_tests.xcresult' -print -quit)"
+            FIND_XCRESULT="$(find $BITRISE_TEST_DEPLOY_DIR -name '*/xcresult3_multi_level_UI_tests.xcresult' -print -quit)"
             if [ -n "$FIND_TEST_INFO" ] && [ -n "$FIND_XCRESULT" ]
             then
               echo "Found exported test results at:"

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 
 	log.SetEnableDebugLog(stepConf.VerboseLog)
 
+	fmt.Println()
 	log.Infof("Searching for test results")
 
 	var matches []string

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bitrise-io/go-steputils/stepconf"
 	"github.com/bitrise-io/go-steputils/testresultexport"
-	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/ryanuber/go-glob"
 )
@@ -26,6 +25,8 @@ func main() {
 	stepconf.Print(stepConf)
 
 	log.SetEnableDebugLog(stepConf.VerboseLog)
+
+	log.Infof("Searching for test results")
 
 	var matches []string
 	basePath := strings.Split(stepConf.BasePath, "*")[0]
@@ -46,24 +47,36 @@ func main() {
 	}
 
 	if len(matches) < 1 {
-		failf("Pattern %s did not match any files within path %s", stepConf.SearchPattern, stepConf.BasePath)
+		failf("Provided search pattern (%s) did not match any files within %s", stepConf.SearchPattern, stepConf.BasePath)
 	}
 
 	if len(matches) > 1 {
-		log.Warnf("Pattern matched more than one file, will use the first match:")
-		for i, m := range matches {
-			template := fmt.Sprintf("- %s\n", m)
-			if i == 0 {
-				template = colorstring.Green(template)
-			}
-			log.Warnf(template)
-		}
+		warnMessage := multipleMatchesWarning(matches)
+		log.Warnf(warnMessage)
 	}
 
 	match := matches[0]
+
+	log.Donef("Exporting test result: %s", match)
+
 	exporter := testresultexport.NewExporter(stepConf.TestResultsDir)
 
 	if err := exporter.ExportTest(stepConf.TestName, match); err != nil {
 		failf("Failed to export test result: %s", err)
 	}
+}
+
+func multipleMatchesWarning(matches []string) string {
+	warnMessage := fmt.Sprintf("Provided search pattern matches %d files:\n", len(matches))
+	for i := 0; i < 5; i++ {
+		if i == len(matches) {
+			break
+		}
+
+		warnMessage += fmt.Sprintf("- %s\n", matches[i])
+	}
+	if len(matches) > 5 {
+		warnMessage += "...\n"
+	}
+	return warnMessage
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import "testing"
+
+func Test_multipleMatchesWarning(t *testing.T) {
+	tests := []struct {
+		name    string
+		matches []string
+		want    string
+	}{
+		{
+			name:    "Five or less matches",
+			matches: []string{"match_1", "match_2", "match_3", "match_4", "match_5"},
+			want: `Provided search pattern matches 5 files:
+- match_1
+- match_2
+- match_3
+- match_4
+- match_5
+`,
+		},
+		{
+			name:    "More than five matches",
+			matches: []string{"match_1", "match_2", "match_3", "match_4", "match_5", "match_6"},
+			want: `Provided search pattern matches 6 files:
+- match_1
+- match_2
+- match_3
+- match_4
+- match_5
+...
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := multipleMatchesWarning(tt.matches); got != tt.want {
+				t.Errorf("multipleMatchesWarning() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/step.yml
+++ b/step.yml
@@ -52,11 +52,9 @@ description: |
 website: https://github.com/bitrise-steplib/step-custom-test-results-export
 source_code_url: https://github.com/bitrise-steplib/step-custom-test-results-export
 support_url: https://github.com/bitrise-steplib/step-custom-test-results-export/issues
-host_os_tags:
-  - osx-10.10
-  - ubuntu-16.04
+
 type_tags:
-  - utility
+- utility
 
 is_requires_admin_user: true
 is_always_run: true
@@ -67,61 +65,60 @@ toolkit:
   go:
     package_name: github.com/bitrise-steplib/step-custom-test-results-export
 
-
 inputs:
-  - test_name:
-    opts:
-      title: "The name of the test"
-      summary: Test name displayed on the tab of the Test Reports page.
-      is_expand: true
-      is_required: true
-      value_options: []
-  - base_path: $BITRISE_SOURCE_DIR
-    opts:
-      title: Test result base path
-      summary: Path where the Step should look for custom test result files
-      description: |
-        You can provide a path to a single file or a directory path and filter for files using the **Test result search pattern** input.
+- test_name:
+  opts:
+    title: The name of the test
+    summary: Test name displayed on the tab of the Test Reports page.
+    is_expand: true
+    is_required: true
+    value_options: []
+- base_path: $BITRISE_SOURCE_DIR
+  opts:
+    title: Test result base path
+    summary: Path where the Step should look for custom test result files
+    description: |
+      You can provide a path to a single file or a directory path and filter for files using the **Test result search pattern** input.
 
-        This is the base path where the Step will look for your test results. We recommend using a relative path to the results:
+      This is the base path where the Step will look for your test results. We recommend using a relative path to the results:
 
-        `app/build/test-results/testDemoDebugUnitTest/`
-        
-        or 
-        
-        `./app/build/test-results/testDemoDebugUnitTest/`
-      is_expand: true
-      is_required: true
-      value_options: []
-  - search_pattern:
-    opts:
-      title: "Test result search pattern"
-      summary: A glob pattern to match a single test report within the base path. 
-      description: |
-        This glob should match a single file within the provided base path.
-        If it matches multiple files, the Step will produce a warning displaying all matches.
-        The matched file should be in a supported format. If you set a specific file path in the **Test result base path** input, set this value to `*`.
-        
-        **Examples**:
-        
-        Matching all files within the base path: `*`
-        
-        Matching all files within a given directory of the base path: `*/build/test-results/testDemoDebugUnitTest/*`
-        
-      is_expand: true
-      is_required: true
-      value_options: []
-  - bitrise_test_result_dir: $BITRISE_TEST_RESULT_DIR
-    opts:
-      title: Step's test result directory
-      description: Root directory for all test results created by the Bitrise CLI
-      is_required: true
-  - verbose_log: "no"
-    opts:
-      category: Debug
-      title: Enable verbose logging?
-      description: Enable verbose logging?
-      is_required: true
-      value_options:
-        - "yes"
-        - "no"
+      `app/build/test-results/testDemoDebugUnitTest/`
+
+      or
+
+      `./app/build/test-results/testDemoDebugUnitTest/`
+    is_expand: true
+    is_required: true
+    value_options: []
+- search_pattern:
+  opts:
+    title: Test result search pattern
+    summary: A glob pattern to match a single test report within the base path.
+    description: |
+      This glob should match a single file within the provided base path.
+      If it matches multiple files, the Step will produce a warning displaying all matches.
+      The matched file should be in a supported format. If you set a specific file path in the **Test result base path** input, set this value to `*`.
+
+      **Examples**:
+
+      Matching all files within the base path: `*`
+
+      Matching all files within a given directory of the base path: `*/build/test-results/testDemoDebugUnitTest/*`
+
+    is_expand: true
+    is_required: true
+    value_options: []
+- bitrise_test_result_dir: $BITRISE_TEST_RESULT_DIR
+  opts:
+    title: Step's test result directory
+    description: Root directory for all test results created by the Bitrise CLI
+    is_required: true
+- verbose_log: "no"
+  opts:
+    category: Debug
+    title: Enable verbose logging?
+    description: Enable verbose logging?
+    is_required: true
+    value_options:
+    - "yes"
+    - "no"


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR improves the Step logging, by limiting the listing of multiple matches to five.
Earlier the Step was printing all the matches, which can be a really long list.

### Changes

- Limit listing multiple matches to five
- Wire in the check workflow
- Update general logging
